### PR TITLE
Add the ability to configure go generate with flags and arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,34 @@
 # Go Generate Cloud Native Buildpack
 
 It is enabled by `BP_GO_GENERATE` being set to `true` in your environment.
+
+## Packaging
+To package this buildpack for use with a CNB platform of choice:
+```
+./scripts/package.sh --version <your-version-number>
+```
+The resulting buildpack (.tgz) and buildpackage (.cnb) will be placed in
+`build/`.
+
+## Configuration
+Use `BP_GO_GENERATE_FLAGS` and `BP_GO_GENERATE_ARGS` in your environment to
+configure the behaviour of `go generate`.
+
+For instance, building an image with
+[`pack`](https://github.com/buildpacks/pack):
+```
+pack build my-app --buildpack gcr.io/paketo-buildpacks/go-dist \
+                  --buildpack gcr.io/paketo-buildpacks/go-mod-vendor \
+                  --buildpack /path/to/repo-dir/go-generate/build/buildpack.tgz \
+                  --buildpack gcr.io/paketo-buildpacks/go-build \
+                  --env BP_GO_GENERATE=true \
+                  --env BP_GO_GENERATE_ARGS='main.go helper.go' \
+                  --env BP_GO_GENERATE_FLAGS='-v -run "^//go:generate sometool"'
+```
+will result in the buildpack running the equivalent of:
+```
+go generate -v -run "^//go:generate sometool" main.go internal.go
+```
+
+See `go help generate` for information about flag and argument options for `go
+generate`.

--- a/build.go
+++ b/build.go
@@ -5,15 +5,26 @@ import (
 	"github.com/paketo-buildpacks/packit/scribe"
 )
 
-//go:generate faux --interface BuildProcess --output fakes/build_process.go
-type BuildProcess interface {
-	Execute(workingDir string) error
+//go:generate faux --interface ConfigurationParser --output fakes/configuration_parser.go
+type ConfigurationParser interface {
+	Parse() (GenerateConfiguration, error)
 }
 
-func Build(buildProcess BuildProcess, logs scribe.Logger) packit.BuildFunc {
+//go:generate faux --interface BuildProcess --output fakes/build_process.go
+type BuildProcess interface {
+	Execute(workingDir string, config GenerateConfiguration) error
+}
+
+func Build(parser ConfigurationParser, buildProcess BuildProcess, logs scribe.Logger) packit.BuildFunc {
 	return func(context packit.BuildContext) (packit.BuildResult, error) {
 		logs.Title("%s %s", context.BuildpackInfo.Name, context.BuildpackInfo.Version)
-		err := buildProcess.Execute(context.WorkingDir)
+
+		config, err := parser.Parse()
+		if err != nil {
+			return packit.BuildResult{}, err
+		}
+
+		err = buildProcess.Execute(context.WorkingDir, config)
 		if err != nil {
 			return packit.BuildResult{}, err
 		}

--- a/detect.go
+++ b/detect.go
@@ -6,15 +6,11 @@ import (
 	"github.com/paketo-buildpacks/packit"
 )
 
-func Detect(parser ConfigurationParser) packit.DetectFunc {
+func Detect() packit.DetectFunc {
 	return func(context packit.DetectContext) (packit.DetectResult, error) {
 		run := os.Getenv("BP_GO_GENERATE")
 		if run != "true" {
 			return packit.DetectResult{}, packit.Fail.WithMessage("BP_GO_GENERATE is empty")
-		}
-
-		if _, err := parser.Parse(); err != nil {
-			return packit.DetectResult{}, packit.Fail.WithMessage("failed to parse go generate configuration: %w", err)
 		}
 
 		return packit.DetectResult{}, nil

--- a/detect.go
+++ b/detect.go
@@ -2,15 +2,21 @@ package gogenerate
 
 import (
 	"os"
+
 	"github.com/paketo-buildpacks/packit"
 )
 
-func Detect() packit.DetectFunc {
+func Detect(parser ConfigurationParser) packit.DetectFunc {
 	return func(context packit.DetectContext) (packit.DetectResult, error) {
 		run := os.Getenv("BP_GO_GENERATE")
 		if run != "true" {
 			return packit.DetectResult{}, packit.Fail.WithMessage("BP_GO_GENERATE is empty")
 		}
+
+		if _, err := parser.Parse(); err != nil {
+			return packit.DetectResult{}, packit.Fail.WithMessage("failed to parse go generate configuration: %w", err)
+		}
+
 		return packit.DetectResult{}, nil
 	}
 }

--- a/detect_test.go
+++ b/detect_test.go
@@ -1,11 +1,13 @@
 package gogenerate_test
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"testing"
 
 	gogenerate "github.com/paketo-buildpacks/go-generate"
+	"github.com/paketo-buildpacks/go-generate/fakes"
 	"github.com/paketo-buildpacks/packit"
 	"github.com/sclevine/spec"
 
@@ -16,22 +18,27 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect = NewWithT(t).Expect
 
-		workingDir  string
-		detect      packit.DetectFunc
+		workingDir string
+		parser     *fakes.ConfigurationParser
+		detect     packit.DetectFunc
 	)
 
 	it.Before(func() {
 		var err error
 		workingDir, err = ioutil.TempDir("", "working-dir")
 		Expect(err).NotTo(HaveOccurred())
+
+		parser = &fakes.ConfigurationParser{}
+		parser.ParseCall.Returns.GenerateConfiguration.Args = []string{"./..."}
+
 		os.Setenv("BP_GO_GENERATE", "true")
-		detect = gogenerate.Detect()
+
+		detect = gogenerate.Detect(parser)
 	})
 
 	it.After(func() {
 		Expect(os.RemoveAll(workingDir)).To(Succeed())
 	})
-
 
 	it("detects", func() {
 		_, err := detect(packit.DetectContext{
@@ -51,6 +58,19 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				WorkingDir: workingDir,
 			})
 			Expect(err).To(MatchError(packit.Fail.WithMessage("BP_GO_GENERATE is empty")))
+		})
+	})
+
+	context("when the configuration parser fails", func() {
+		it.Before(func() {
+			parser.ParseCall.Returns.Error = errors.New("failed to parse configuration")
+		})
+
+		it("returns an error", func() {
+			_, err := detect(packit.DetectContext{
+				WorkingDir: workingDir,
+			})
+			Expect(err).To(MatchError(ContainSubstring("failed to parse configuration")))
 		})
 	})
 }

--- a/detect_test.go
+++ b/detect_test.go
@@ -1,13 +1,11 @@
 package gogenerate_test
 
 import (
-	"errors"
 	"io/ioutil"
 	"os"
 	"testing"
 
 	gogenerate "github.com/paketo-buildpacks/go-generate"
-	"github.com/paketo-buildpacks/go-generate/fakes"
 	"github.com/paketo-buildpacks/packit"
 	"github.com/sclevine/spec"
 
@@ -19,7 +17,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		Expect = NewWithT(t).Expect
 
 		workingDir string
-		parser     *fakes.ConfigurationParser
 		detect     packit.DetectFunc
 	)
 
@@ -28,12 +25,9 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		workingDir, err = ioutil.TempDir("", "working-dir")
 		Expect(err).NotTo(HaveOccurred())
 
-		parser = &fakes.ConfigurationParser{}
-		parser.ParseCall.Returns.GenerateConfiguration.Args = []string{"./..."}
-
 		os.Setenv("BP_GO_GENERATE", "true")
 
-		detect = gogenerate.Detect(parser)
+		detect = gogenerate.Detect()
 	})
 
 	it.After(func() {
@@ -58,19 +52,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				WorkingDir: workingDir,
 			})
 			Expect(err).To(MatchError(packit.Fail.WithMessage("BP_GO_GENERATE is empty")))
-		})
-	})
-
-	context("when the configuration parser fails", func() {
-		it.Before(func() {
-			parser.ParseCall.Returns.Error = errors.New("failed to parse configuration")
-		})
-
-		it("returns an error", func() {
-			_, err := detect(packit.DetectContext{
-				WorkingDir: workingDir,
-			})
-			Expect(err).To(MatchError(ContainSubstring("failed to parse configuration")))
 		})
 	})
 }

--- a/fakes/build_process.go
+++ b/fakes/build_process.go
@@ -1,6 +1,10 @@
 package fakes
 
-import "sync"
+import (
+	"sync"
+
+	gogenerate "github.com/paketo-buildpacks/go-generate"
+)
 
 type BuildProcess struct {
 	ExecuteCall struct {
@@ -8,21 +12,23 @@ type BuildProcess struct {
 		CallCount int
 		Receives  struct {
 			WorkingDir string
+			Config     gogenerate.GenerateConfiguration
 		}
 		Returns struct {
 			Error error
 		}
-		Stub func(string) error
+		Stub func(string, gogenerate.GenerateConfiguration) error
 	}
 }
 
-func (f *BuildProcess) Execute(param1 string) error {
+func (f *BuildProcess) Execute(param1 string, param2 gogenerate.GenerateConfiguration) error {
 	f.ExecuteCall.Lock()
 	defer f.ExecuteCall.Unlock()
 	f.ExecuteCall.CallCount++
 	f.ExecuteCall.Receives.WorkingDir = param1
+	f.ExecuteCall.Receives.Config = param2
 	if f.ExecuteCall.Stub != nil {
-		return f.ExecuteCall.Stub(param1)
+		return f.ExecuteCall.Stub(param1, param2)
 	}
 	return f.ExecuteCall.Returns.Error
 }

--- a/fakes/configuration_parser.go
+++ b/fakes/configuration_parser.go
@@ -1,0 +1,29 @@
+package fakes
+
+import (
+	"sync"
+
+	gogenerate "github.com/paketo-buildpacks/go-generate"
+)
+
+type ConfigurationParser struct {
+	ParseCall struct {
+		sync.Mutex
+		CallCount int
+		Returns   struct {
+			GenerateConfiguration gogenerate.GenerateConfiguration
+			Error                 error
+		}
+		Stub func() (gogenerate.GenerateConfiguration, error)
+	}
+}
+
+func (f *ConfigurationParser) Parse() (gogenerate.GenerateConfiguration, error) {
+	f.ParseCall.Lock()
+	defer f.ParseCall.Unlock()
+	f.ParseCall.CallCount++
+	if f.ParseCall.Stub != nil {
+		return f.ParseCall.Stub()
+	}
+	return f.ParseCall.Returns.GenerateConfiguration, f.ParseCall.Returns.Error
+}

--- a/generate.go
+++ b/generate.go
@@ -29,9 +29,11 @@ func NewGenerate(executable Executable, logs scribe.Logger, clock chronos.Clock)
 	}
 }
 
-func (g Generate) Execute(workingDir string) error {
+func (g Generate) Execute(workingDir string, config GenerateConfiguration) error {
 	buffer := bytes.NewBuffer(nil)
-	args := []string{"generate", "./..."}
+
+	args := append([]string{"generate"}, config.Flags...)
+	args = append(args, config.Args...)
 
 	g.logs.Process("Executing build process")
 	g.logs.Subprocess("Running 'go %s'", strings.Join(args, " "))

--- a/generate_configuration_parser.go
+++ b/generate_configuration_parser.go
@@ -1,0 +1,48 @@
+package gogenerate
+
+import (
+	"os"
+
+	"github.com/mattn/go-shellwords"
+)
+
+type GenerateConfiguration struct {
+	Args  []string
+	Flags []string
+}
+
+type GenerateConfigurationParser struct {
+}
+
+func NewGenerateConfigurationParser() GenerateConfigurationParser {
+	return GenerateConfigurationParser{}
+}
+
+func (p GenerateConfigurationParser) Parse() (GenerateConfiguration, error) {
+	var (
+		generateConfiguration GenerateConfiguration
+		err                   error
+		shellwordsParser      *shellwords.Parser
+	)
+
+	shellwordsParser = shellwords.NewParser()
+	shellwordsParser.ParseEnv = true
+
+	generateConfiguration.Args = []string{"./..."}
+	if val, ok := os.LookupEnv("BP_GO_GENERATE_ARGS"); ok {
+		generateConfiguration.Args, err = shellwordsParser.Parse(val)
+
+		if err != nil {
+			return GenerateConfiguration{}, err
+		}
+	}
+
+	if val, ok := os.LookupEnv("BP_GO_GENERATE_FLAGS"); ok {
+		generateConfiguration.Flags, err = shellwordsParser.Parse(val)
+
+		if err != nil {
+			return GenerateConfiguration{}, err
+		}
+	}
+	return generateConfiguration, nil
+}

--- a/generate_configuration_parser_test.go
+++ b/generate_configuration_parser_test.go
@@ -1,0 +1,103 @@
+package gogenerate_test
+
+import (
+	"os"
+	"testing"
+
+	gogenerate "github.com/paketo-buildpacks/go-generate"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testGenerateConfigurationParser(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		parser gogenerate.GenerateConfigurationParser
+	)
+
+	it.Before(func() {
+		parser = gogenerate.NewGenerateConfigurationParser()
+	})
+
+	context("BP_GO_GENERATE_ARGS is set", func() {
+		it.Before(func() {
+			os.Setenv("BP_GO_GENERATE_ARGS", "somemodule othermodule")
+		})
+
+		it.After(func() {
+			os.Unsetenv("BP_GO_GENERATE_ARGS")
+		})
+
+		it("uses the values in the env var", func() {
+			configuration, err := parser.Parse()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configuration).To(Equal(gogenerate.GenerateConfiguration{
+				Args: []string{"somemodule", "othermodule"},
+			}))
+		})
+	}, spec.Sequential())
+
+	context("BP_GO_GENERATE_ARGS is NOT set", func() {
+		it("uses the default value", func() {
+			configuration, err := parser.Parse()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configuration).To(Equal(gogenerate.GenerateConfiguration{
+				Args: []string{"./..."},
+			}))
+		})
+	}, spec.Sequential())
+
+	context("BP_GO_GENERATE_FLAGS is set", func() {
+		it.Before(func() {
+			os.Setenv("BP_GO_GENERATE_FLAGS", `-run="^//go:generate go get" -n`)
+		})
+
+		it.After(func() {
+			os.Unsetenv("BP_GO_GENERATE_FLAGS")
+		})
+
+		it("uses the values in the env var", func() {
+			configuration, err := parser.Parse()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configuration).To(Equal(gogenerate.GenerateConfiguration{
+				Args:  []string{"./..."},
+				Flags: []string{`-run=^//go:generate go get`, "-n"},
+			}))
+		})
+	}, spec.Sequential())
+
+	context("failure cases", func() {
+
+		context("generate args fail to parse", func() {
+			it.Before(func() {
+				os.Setenv("BP_GO_GENERATE_ARGS", "\"")
+			})
+
+			it("returns an error", func() {
+				_, err := parser.Parse()
+				Expect(err).To(MatchError(ContainSubstring("invalid command line string")))
+			})
+
+			it.After(func() {
+				os.Unsetenv("BP_GO_GENERATE_ARGS")
+			})
+		}, spec.Sequential())
+
+		context("generate flags fail to parse", func() {
+			it.Before(func() {
+				os.Setenv("BP_GO_GENERATE_FLAGS", "\"")
+			})
+
+			it("returns an error", func() {
+				_, err := parser.Parse()
+				Expect(err).To(MatchError(ContainSubstring("invalid command line string")))
+			})
+
+			it.After(func() {
+				os.Unsetenv("BP_GO_GENERATE_ARGS")
+			})
+		}, spec.Sequential())
+	})
+}

--- a/generate_test.go
+++ b/generate_test.go
@@ -60,14 +60,22 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	context("Execute", func() {
-		it("runs go generate ./...", func() {
-			err := generate.Execute(workingDir)
+		it("executes the go generate process", func() {
+			err := generate.Execute(workingDir, gogenerate.GenerateConfiguration{
+				Args:  []string{"main.go", "somemodule"},
+				Flags: []string{"-n"},
+			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{"generate", "./..."}))
+			Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{
+				"generate",
+				"-n",
+				"main.go",
+				"somemodule",
+			}))
 			Expect(executable.ExecuteCall.Receives.Execution.Dir).To(Equal(workingDir))
 
 			Expect(logs.String()).To(ContainSubstring("  Executing build process"))
-			Expect(logs.String()).To(ContainSubstring("    Running 'go generate ./...'"))
+			Expect(logs.String()).To(ContainSubstring(`    Running 'go generate -n main.go somemodule'`))
 			Expect(logs.String()).To(ContainSubstring("      Completed in 1s"))
 		})
 
@@ -83,7 +91,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 				})
 
 				it("returns an error", func() {
-					err := generate.Execute(workingDir)
+					err := generate.Execute(workingDir, gogenerate.GenerateConfiguration{Args: []string{"./..."}})
 					Expect(err).To(MatchError(ContainSubstring("executable failed")))
 
 					Expect(logs.String()).To(ContainSubstring("      Failed after 1s"))

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,8 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/google/go-cmp v0.5.4 // indirect
-	github.com/hashicorp/hcl v1.0.0
 	github.com/mattn/go-shellwords v1.0.11-0.20201201010856-2c8720de5e83
 	github.com/onsi/gomega v1.10.5
-	github.com/paketo-buildpacks/go-build v0.2.2
 	github.com/paketo-buildpacks/occam v0.1.1
 	github.com/paketo-buildpacks/packit v0.7.0
 	github.com/sclevine/spec v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,10 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/google/go-cmp v0.5.4 // indirect
+	github.com/hashicorp/hcl v1.0.0
+	github.com/mattn/go-shellwords v1.0.11-0.20201201010856-2c8720de5e83
 	github.com/onsi/gomega v1.10.5
+	github.com/paketo-buildpacks/go-build v0.2.2
 	github.com/paketo-buildpacks/occam v0.1.1
 	github.com/paketo-buildpacks/packit v0.7.0
 	github.com/sclevine/spec v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 h1:k6UDF1uPYOs0iy1HPeotNa155qXRWrzKnqAaGXHLZCE=
+github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251/go.mod h1:gbPR1gPu9dB96mucYIR7T3B7p/78hRVSOuzIWLHK2Y4=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cheggaaa/pb/v3 v3.0.5 h1:lmZOti7CraK9RSjzExsY53+WWfub9Qv13B5m4ptEoPE=
@@ -233,6 +235,7 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -284,6 +287,8 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/mattn/go-runewidth v0.0.8/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-shellwords v1.0.11-0.20201201010856-2c8720de5e83 h1:JO7FIZAhVSx3GNEY1jug85wRYiXsRyJYlvtGflP+kgA=
+github.com/mattn/go-shellwords v1.0.11-0.20201201010856-2c8720de5e83/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -326,10 +331,14 @@ github.com/onsi/gomega v1.10.5/go.mod h1:gza4q3jKQJijlu05nKWRCW/GavJumGt8aNRxWg7
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+github.com/paketo-buildpacks/go-build v0.2.2 h1:qI25nGYo4kA/58WDYkzVYuPV2goSPjet8+DJYTDDz0c=
+github.com/paketo-buildpacks/go-build v0.2.2/go.mod h1:tc4PXsGMxCACnxbj7e9ykJN5QLLoO+HHWVCkJdr56G0=
 github.com/paketo-buildpacks/occam v0.0.22/go.mod h1:aPNRyPEgYp4a01O4UKAuFWYnRmY4ujeuV3x6yAa1hxs=
+github.com/paketo-buildpacks/occam v0.1.0/go.mod h1:zVBTsX7yrOGtmwBv9vE59U8BWKjaygScv0DKoIgoGXk=
 github.com/paketo-buildpacks/occam v0.1.1 h1:gTnURjctcWY1fURmxh+ERm0ONFGqsGBE6VvusBysgQk=
 github.com/paketo-buildpacks/occam v0.1.1/go.mod h1:bV568K2TWVHsuDBF9akaYA7HViQRYMoU1OwhwNy6PE0=
 github.com/paketo-buildpacks/packit v0.5.0/go.mod h1:ATLZccUzqEAyPlirdka8hs+XNqS4pyJ/tjyU1NXJKm8=
+github.com/paketo-buildpacks/packit v0.6.1/go.mod h1:lAtWn4LbA5f6sxfTNdhCV1z1KWBNACNeSgCpsuLDeeo=
 github.com/paketo-buildpacks/packit v0.7.0 h1:Xvy6If3GPd+nAqk+bB4xoJ8eUitoMboKdrzhW08uXD4=
 github.com/paketo-buildpacks/packit v0.7.0/go.mod h1:b498Gw+ZwwAxhqGpeRprrLKr5m9dVdRGvdwEDq2GBEk=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -395,6 +404,7 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/ulikunitz/xz v0.5.9/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,6 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 h1:k6UDF1uPYOs0iy1HPeotNa155qXRWrzKnqAaGXHLZCE=
-github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251/go.mod h1:gbPR1gPu9dB96mucYIR7T3B7p/78hRVSOuzIWLHK2Y4=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cheggaaa/pb/v3 v3.0.5 h1:lmZOti7CraK9RSjzExsY53+WWfub9Qv13B5m4ptEoPE=
@@ -331,14 +329,10 @@ github.com/onsi/gomega v1.10.5/go.mod h1:gza4q3jKQJijlu05nKWRCW/GavJumGt8aNRxWg7
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/paketo-buildpacks/go-build v0.2.2 h1:qI25nGYo4kA/58WDYkzVYuPV2goSPjet8+DJYTDDz0c=
-github.com/paketo-buildpacks/go-build v0.2.2/go.mod h1:tc4PXsGMxCACnxbj7e9ykJN5QLLoO+HHWVCkJdr56G0=
 github.com/paketo-buildpacks/occam v0.0.22/go.mod h1:aPNRyPEgYp4a01O4UKAuFWYnRmY4ujeuV3x6yAa1hxs=
-github.com/paketo-buildpacks/occam v0.1.0/go.mod h1:zVBTsX7yrOGtmwBv9vE59U8BWKjaygScv0DKoIgoGXk=
 github.com/paketo-buildpacks/occam v0.1.1 h1:gTnURjctcWY1fURmxh+ERm0ONFGqsGBE6VvusBysgQk=
 github.com/paketo-buildpacks/occam v0.1.1/go.mod h1:bV568K2TWVHsuDBF9akaYA7HViQRYMoU1OwhwNy6PE0=
 github.com/paketo-buildpacks/packit v0.5.0/go.mod h1:ATLZccUzqEAyPlirdka8hs+XNqS4pyJ/tjyU1NXJKm8=
-github.com/paketo-buildpacks/packit v0.6.1/go.mod h1:lAtWn4LbA5f6sxfTNdhCV1z1KWBNACNeSgCpsuLDeeo=
 github.com/paketo-buildpacks/packit v0.7.0 h1:Xvy6If3GPd+nAqk+bB4xoJ8eUitoMboKdrzhW08uXD4=
 github.com/paketo-buildpacks/packit v0.7.0/go.mod h1:b498Gw+ZwwAxhqGpeRprrLKr5m9dVdRGvdwEDq2GBEk=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -404,7 +398,6 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/ulikunitz/xz v0.5.9/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/go.sum
+++ b/go.sum
@@ -233,7 +233,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/init_test.go
+++ b/init_test.go
@@ -12,5 +12,6 @@ func TestUnitGoGenerate(t *testing.T) {
 	suite("Build", testBuild)
 	suite("Detect", testDetect)
 	suite("Generate", testGenerate)
+	suite("GenerateConfigurationParser", testGenerateConfigurationParser)
 	suite.Run(t)
 }

--- a/integration.json
+++ b/integration.json
@@ -1,4 +1,5 @@
 {
   "go-dist": "github.com/paketo-buildpacks/go-dist",
-  "go-mod-vendor": "github.com/paketo-buildpacks/go-mod-vendor"
+  "go-mod-vendor": "github.com/paketo-buildpacks/go-mod-vendor",
+  "build-plan": "github.com/paketo-community/build-plan"
 }

--- a/integration/args_flags_test.go
+++ b/integration/args_flags_test.go
@@ -1,0 +1,89 @@
+package integration_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/occam"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
+)
+
+func testArgsAndFlags(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		pack   occam.Pack
+		docker occam.Docker
+
+		image     occam.Image
+		container occam.Container
+
+		name   string
+		source string
+	)
+
+	it.Before(func() {
+		pack = occam.NewPack().WithVerbose().WithNoColor()
+		docker = occam.NewDocker()
+	})
+
+	context("building a simple app using BP_GO_GENERATE_ARGS and BP_GO_GENERATE_FLAGS", func() {
+		it.Before(func() {
+			var err error
+			name, err = occam.RandomName()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		it.After(func() {
+			Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
+			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+			Expect(os.RemoveAll(source)).To(Succeed())
+		})
+
+		it("successfully passes args to go generate", func() {
+			var err error
+			source, err = occam.Source(filepath.Join("testdata", "args_and_flags"))
+			Expect(err).NotTo(HaveOccurred())
+
+			var logs fmt.Stringer
+			image, logs, err = pack.Build.
+				WithPullPolicy("never").
+				WithBuildpacks(
+					settings.Buildpacks.GoDist.Online,
+					settings.Buildpacks.GoGenerate.Online,
+					settings.Buildpacks.BuildPlan.Online,
+				).
+				WithEnv(map[string]string{
+					"BP_GO_GENERATE":       "true",
+					"BP_GO_GENERATE_ARGS":  "main.go",
+					"BP_GO_GENERATE_FLAGS": `-run "^//go:generate sleep"`,
+				}).
+				Execute(name, source)
+			Expect(err).ToNot(HaveOccurred(), logs.String)
+
+			Expect(logs).To(ContainLines(
+				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
+				"  Executing build process",
+				"    Running 'go generate -run ^//go:generate sleep main.go'",
+				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
+			))
+
+			container, err = docker.Container.Run.
+				WithCommand("ls -alR /workspace").
+				Execute(image.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			logs, err = docker.Container.Logs.Execute(container.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(logs.String()).NotTo(ContainSubstring("main_moved.txt"))
+			Expect(logs.String()).NotTo(ContainSubstring("internal_moved.txt"))
+		})
+	})
+}

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -23,6 +23,9 @@ var settings struct {
 		GoModVendor struct {
 			Online string
 		}
+		BuildPlan struct {
+			Online string
+		}
 		GoGenerate struct {
 			Online string
 		}
@@ -34,6 +37,7 @@ var settings struct {
 	Config struct {
 		GoDist      string `json:"go-dist"`
 		GoModVendor string `json:"go-mod-vendor"`
+		BuildPlan   string `json:"build-plan"`
 	}
 }
 
@@ -71,9 +75,14 @@ func TestIntegration(t *testing.T) {
 		Execute(settings.Config.GoModVendor)
 	Expect(err).ToNot(HaveOccurred())
 
+	settings.Buildpacks.BuildPlan.Online, err = buildpackStore.Get.
+		Execute(settings.Config.BuildPlan)
+	Expect(err).ToNot(HaveOccurred())
+
 	SetDefaultEventuallyTimeout(10 * time.Second)
 
 	suite := spec.New("Integration", spec.Report(report.Terminal{}), spec.Parallel())
 	suite("Default", testDefault)
+	suite("ArgsAndFlags", testArgsAndFlags)
 	suite.Run(t)
 }

--- a/integration/testdata/args_and_flags/internal/helper.go
+++ b/integration/testdata/args_and_flags/internal/helper.go
@@ -1,0 +1,12 @@
+package internal
+
+import "fmt"
+
+//go:generate mv /workspace/internal.txt /workspace/internal_moved.txt
+//go:generate sleep 5
+
+func helper() {
+	if true {
+		fmt.Println("hello world!")
+	}
+}

--- a/integration/testdata/args_and_flags/main.go
+++ b/integration/testdata/args_and_flags/main.go
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+
+//go:generate mv /workspace/main.txt /workspace/main_moved.txt
+//go:generate sleep 5
+
+func main() {
+	if true {
+		fmt.Println("hello world!")
+	}
+}

--- a/integration/testdata/args_and_flags/plan.toml
+++ b/integration/testdata/args_and_flags/plan.toml
@@ -1,0 +1,7 @@
+[[requires]]
+name = "go"
+
+[requires.metadata]
+  build=true
+  launch=true
+

--- a/run/main.go
+++ b/run/main.go
@@ -12,12 +12,11 @@ import (
 
 func main() {
 	logger := scribe.NewLogger(os.Stdout)
-	configParser := gogenerate.NewGenerateConfigurationParser()
 
 	packit.Run(
-		gogenerate.Detect(configParser),
+		gogenerate.Detect(),
 		gogenerate.Build(
-			configParser,
+			gogenerate.NewGenerateConfigurationParser(),
 			gogenerate.NewGenerate(
 				pexec.NewExecutable("go"),
 				logger,

--- a/run/main.go
+++ b/run/main.go
@@ -12,10 +12,12 @@ import (
 
 func main() {
 	logger := scribe.NewLogger(os.Stdout)
+	configParser := gogenerate.NewGenerateConfigurationParser()
 
 	packit.Run(
-		gogenerate.Detect(),
+		gogenerate.Detect(configParser),
 		gogenerate.Build(
+			configParser,
 			gogenerate.NewGenerate(
 				pexec.NewExecutable("go"),
 				logger,


### PR DESCRIPTION
`BP_GO_GENERATE_ARGS` and `BP_GO_GENERATE_FLAGS` can be used to get finer-grained control of what the buildpack does. These env vars were described in https://github.com/paketo-buildpacks/go/pull/367.